### PR TITLE
feat(collection): calculate and display total remaining unpaid

### DIFF
--- a/src/app/components/collection/collection.component.html
+++ b/src/app/components/collection/collection.component.html
@@ -97,8 +97,7 @@
   <!-- Table Section -->
   <div class="box table-section">
     <div class="table-header">
-      <h2>Unpaid Collections</h2>
-      <!-- Keep the filter button and input field structure, but adjust its position/usage slightly if needed -->
+      <h2>Unpaid Collections (Total Unpaid Amount: {{ totalRemainingUnpaid | currency:'INR' }})</h2>
        <div class="filter-container" [class.show-filter]="showFilter">
             <mat-form-field appearance="outline" class="filter-field">
                 <mat-label>Filter by Apartment</mat-label>

--- a/src/app/components/collection/collection.component.ts
+++ b/src/app/components/collection/collection.component.ts
@@ -108,6 +108,7 @@ export class CollectionComponent implements OnInit, AfterViewInit {
   totalDemand = 0;
   totalCollection = 0;
   collectionRate = 0;
+  totalRemainingUnpaid: number = 0;
 
   dataSource = new MatTableDataSource<DisplayRow>();
   @ViewChild('filterInput') filterInput!: ElementRef;
@@ -224,6 +225,7 @@ export class CollectionComponent implements OnInit, AfterViewInit {
       this.collectionService.getUnpaidFees().subscribe({
         next: (fees) => {
           this.originalUnpaidFees = fees;
+          this.calculateTotalRemainingUnpaid();
           this.paymentForms.clear();
           this.originalUnpaidFees.forEach((fee, index) => {
             this.paymentForms.push(this.fb.group({
@@ -243,11 +245,18 @@ export class CollectionComponent implements OnInit, AfterViewInit {
           console.error('Failed to load unpaid fees:', err);
           this.snackBar.open('Failed to load unpaid fees.', 'Close', { duration: 3000 });
           this.originalUnpaidFees = [];
+          this.calculateTotalRemainingUnpaid();
           this.applyFilter();
           resolve();
         }
       });
     });
+  }
+
+  private calculateTotalRemainingUnpaid(): void {
+    this.totalRemainingUnpaid = this.originalUnpaidFees.reduce(
+        (sum, fee) => sum + fee.remainingAmount, 0
+    );
   }
 
   private groupFees(fees: UnpaidFeeDto[]): Map<string, UnpaidFeeDto[]> {


### PR DESCRIPTION
### Pull Request Description

**Title:** feat(collection): calculate and display total remaining unpaid

**Description:**
This pull request introduces a new feature that calculates and displays the total remaining unpaid fees within the collection component. The key changes include:

- A new method has been added to compute the total unpaid fees.
- The user interface has been updated to show this total in the header, enhancing visibility for users.
- The calculation is performed after fetching the unpaid fees, and it includes error handling to ensure that the displayed amount remains accurate at all times.

These improvements aim to increase user awareness regarding the total unpaid amount, thereby facilitating better financial management within the application. 

**Commits:**
- feat(collection): calculate and display total remaining unpaid

This commit encapsulates the functionality described above, ensuring a seamless integration of the new feature into the existing codebase.